### PR TITLE
ci(tox): move pip install to deps section; installation happens once

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,9 @@ envlist =
 allowlist_externals = pytest
 setenv =
     SHOSHIN_ENV_FILE = .env.testing
+deps =
+    -e .[dev]
 commands =
-    pip install -e .[dev]
     pytest tests/ --cov shoshin -s -v
 
 [testenv:lint]


### PR DESCRIPTION
### Proposed Changes:

Use `deps` directive instead of doing `pip install ...` in the commands list. Improves `tox` usage speed in local development (dependencies are installed only once).

### Testing:

None.

### Extra Notes (optional):

None.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) and adhere to [contributor guidelines](https://github.com/palazzem/shoshin/blob/main/CONTRIBUTING.md)
- [x] Code is well-documented via docstrings
- [x] [Pre-commit hooks](https://github.com/palazzem/shoshin#dev-environment) have been installed and run correctly, and issues are fixed.
